### PR TITLE
Update to "Access Zeppelin from a public agent"

### DIFF
--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -22,7 +22,7 @@ sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-On DC/OS 1.7 and below, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
+On DC/OS >1.7, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -22,7 +22,7 @@ sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-On DC/OS >1.7, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
+On DC/OS <1.7, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -22,7 +22,7 @@ sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-If you wish to access Zeppelin from a public agent, you can install marathon-lb on a public agent, then launch Zeppelin with a label for discovery by marathon-lb, [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
+If you wish to access Zeppelin from the public internet, use marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -1,45 +1,69 @@
 Apache Zeppelin is an interactive analytics notebook compatible with
-several backends, including [DCOS
+several backends, including [DC/OS
 Spark](https://docs.mesosphere.com/spark-1-7/).
 
-DCOS Zeppelin bundles Apache Zeppelin with the DCOS Spark
+DC/OS Zeppelin bundles Apache Zeppelin with the DC/OS Spark
 distribution.  For complete Apache Zeppelin docs, please visit [their
 website](https://zeppelin.incubator.apache.org/).
 
 # Install
-
+ 
 ```
 $ dcos package install zeppelin
 ```
 
-## Install on DCOS 1.7 and above
-On DCOS >= 1.7, you can now access Zeppelin at
+## Install on DC/OS 1.7 and above
+On DC/OS >= 1.7, you can now access Zeppelin at
 `http://<dcos_url>/service/zeppelin/` after running the above command.
 
 **Note:** Zeppelin uses websockets, which communicate over raw TCP
-sockets, rather than HTTP.  On AWS DCOS 1.7, the ELB to which
+sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
 `<dcos_url>` resolves will proxy HTTP traffic, but not TCP.  For
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-## Install on a public agent
+## Access Zeppelin from a public agent
  
+Use the marathon-lb DC/OS service to make Zeppelin accessible from a public agent.
+
+1. From the DC/OS web interface, click the **Universe** tab, choose **marathon-lb**, and click **Install**.
+
+Alternatively, you can install marathon-lb from the DC/OS CLI:
+
+```bash
+$ dcos package install marathon-lb
+```
+
+1. Add the following parameter to the Marathon application that will interact with Zeppelin:
+
+```json
+{
+     "labels": {
+       "HAPROXY_0_VHOST": "<public-agent-hostname>"
+     }
+   }
+```
+
+When you launch the Marathon application, you should be able to access Zeppelin at `https://<dcos_url>/service/zeppelin/`, where `dcos_url` is the address of the DC/OS web interface for your cluster.
+
+<!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the
 `acceptedResourceRoles` field of the Marathon app to
 `["slave_public"]`.  You can then access Zeppelin By combining the
 public IP address of the agent running Zeppelin with the `$PORT0` of
 its marathon app.
+-->
 
 # Usage
 
 ## Spark
 
 Zeppelin is bundled with the Spark distribution specified by the
-configuration variable `spark.uri`.  DCOS Zeppelin fetches this
+configuration variable `spark.uri`.  DC/OS Zeppelin fetches this
 distribution and sets the `SPARK_HOME` of its Spark client to this
 location.  Executors will run in the docker image specified by
 `spark.executor_docker_image`.  By default, these are configured to be
-a recent DCOS Spark distribution.
+a recent DC/OS Spark distribution.
 
 ### Testing
 
@@ -53,5 +77,5 @@ rdd.sum()
 
 After a short period, "15" should be printed.
 
-**NOTE**: The first Spark job you run on a new DCOS cluster may take
+**NOTE**: The first Spark job you run on a new DC/OS cluster may take
 some time as the docker images are being pulled down.

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -22,29 +22,7 @@ sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-## Access Zeppelin from a public agent
- 
-Use the marathon-lb DC/OS service to make Zeppelin accessible from a public agent.
-
-1. From the DC/OS web interface, click the **Universe** tab, choose **marathon-lb**, and click **Install**.
-
-Alternatively, you can install marathon-lb from the DC/OS CLI:
-
-```bash
-$ dcos package install marathon-lb
-```
-
-1. Add the following parameter to the Marathon application that will interact with Zeppelin:
-
-```json
-{
-     "labels": {
-       "HAPROXY_0_VHOST": "<public-agent-hostname>"
-     }
-   }
-```
-
-When you launch the Marathon application, you should be able to access Zeppelin at `https://<dcos_url>/service/zeppelin/`, where `dcos_url` is the address of the DC/OS web interface for your cluster.
+If you wish to access Zeppelin from a public agent, you can install marathon-lb on a public agent, then launch Zeppelin with a label for discovery by marathon-lb, [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -22,7 +22,7 @@ sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-If you wish to access Zeppelin from the public internet, use marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
+On DC/OS 1.7 and below, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the


### PR DESCRIPTION
- added instructions on using marathon-lb
- changed instances of DCOS to DC/OS
