### PR TITLE
#4 - upgrading to latest zeppelin release and run with user zeppelin 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,18 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 # zeppelin
-RUN wget http://apache.arvixe.com/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz
-RUN tar xzvf zeppelin-0.5.6-incubating-bin-all.tgz
-WORKDIR /zeppelin-0.5.6-incubating-bin-all
+RUN wget http://mirror.serversupportforum.de/apache/zeppelin/zeppelin-0.6.0/zeppelin-0.6.0-bin-all.tgz
+RUN tar xzvf zeppelin-0.6.0-bin-all.tgz
+WORKDIR /zeppelin-0.6.0-bin-all
 ADD zeppelin-env.sh conf/zeppelin-env.sh
+
+# add our user and group first to make sure their IDs get assigned consistently
+RUN groupadd -r zeppelin && useradd -r -m -g zeppelin zeppelin
+
+RUN \
+	chown -R zeppelin:zeppelin /zeppelin-0.6.0-bin-all && \
+    chown -R zeppelin:zeppelin /etc/hadoop
+
+USER zeppelin
 
 CMD ["bin/zeppelin.sh", "start"]


### PR DESCRIPTION
In response to Issue #4 , I created this PR. This also switches to the official Zeppelin 0.6.0 release as the 0.5.6 version referenced in the master branch is no longer available at the given URL. Pull request #2 has been open for a while and changes to a self-built 0.6.0. This should be investigated by someone more involved than me.