### PR TITLE
update to zeppelin 0.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mesosphere/mesos:0.26.0-0.2.145.ubuntu1404
+FROM mesosphere/mesos:1.0.11.0.1-2.0.93.ubuntu1404
 
 RUN apt-get update && \
     apt-get install -y software-properties-common
@@ -20,9 +20,9 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 # zeppelin
-RUN wget http://apache.arvixe.com/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz
-RUN tar xzvf zeppelin-0.5.6-incubating-bin-all.tgz
-WORKDIR /zeppelin-0.5.6-incubating-bin-all
+RUN wget http://www.apache.org/dist/zeppelin/zeppelin-0.6.1/zeppelin-0.6.1-bin-all.tgz
+RUN tar xzvf zeppelin-0.6.1-bin-all.tgz
+WORKDIR /zeppelin-0.6.1-bin-all
 ADD zeppelin-env.sh conf/zeppelin-env.sh
 
 CMD ["bin/zeppelin.sh", "start"]

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -1,6 +1,6 @@
 Apache Zeppelin is an interactive analytics notebook compatible with
 several backends, including [DC/OS
-Spark](https://docs.mesosphere.com/spark-1-7/).
+Spark](https://docs.mesosphere.com/1.8/usage/service-guides/spark/).
 
 DC/OS Zeppelin bundles Apache Zeppelin with the DC/OS Spark
 distribution.  For complete Apache Zeppelin docs, please visit [their
@@ -12,17 +12,17 @@ website](https://zeppelin.incubator.apache.org/).
 $ dcos package install zeppelin
 ```
 
-## Install on DC/OS 1.7 and above
-On DC/OS >= 1.7, you can now access Zeppelin at
+## Install on DC/OS 1.8 and above
+On DC/OS >= 1.8, you can now access Zeppelin at
 `http://<dcos_url>/service/zeppelin/` after running the above command.
 
 **Note:** Zeppelin uses websockets, which communicate over raw TCP
-sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
+sockets, rather than HTTP.  On AWS DC/OS 1.8, the ELB to which
 `<dcos_url>` resolves will proxy HTTP traffic, but not TCP.  For
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-On DC/OS <1.7, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
+On DC/OS <1.8, you can access Zeppelin from the public internet by using marathon-lb [as described here](https://docs.mesosphere.com/1.8/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
     "packagingVersion": "2.0",
     "name": "zeppelin",
-    "version": "0.5.6",
+    "version": "0.6.1",
     "scm": "https://github.com/apache/incubator-zeppelin",
     "maintainer": "support@mesosphere.io",
     "description": "Zeppelin is a web-based notebook that enables interactive data analytics",

--- a/package/resource.json
+++ b/package/resource.json
@@ -7,12 +7,12 @@
   "assets": {
     "container": {
       "docker": {
-        "zeppelin": "mesosphere/zeppelin:0.5.6-3",
-        "spark": "mesosphere/spark:1.6.0"
+        "zeppelin": "mesosphere/zeppelin:0.6.1",
+        "spark": "mesosphere/spark:1.0.2-2.0.0"
       }
     },
     "uris": {
-      "spark": "https://downloads.mesosphere.io/spark/assets/spark-1.6.0.tgz"
+      "spark": "https://downloads.mesosphere.io/spark/assets/spark-2.0.0.tgz"
     }
   }
 }


### PR DESCRIPTION
can you please push the docker image to docker hub.

i used zutherb/zeppelin:0.6.1 to try if it works