### PR TITLE
Upgrade to Zeppelin 0.6.2 and install all missing R & Python packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is the docker build for Zeppelin on DCOS.
 ## Building
 
 ```sh
+cd docker
 docker build -t mesosphere/zeppelin:<version> .
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,9 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 # zeppelin
-RUN wget http://www.apache.org/dist/zeppelin/zeppelin-0.6.1/zeppelin-0.6.1-bin-all.tgz
-RUN tar xzvf zeppelin-0.6.1-bin-all.tgz
-WORKDIR /zeppelin-0.6.1-bin-all
+RUN wget http://www.apache.org/dist/zeppelin/zeppelin-0.6.2/zeppelin-0.6.2-bin-all.tgz
+RUN tar xzvf zeppelin-0.6.2-bin-all.tgz
+WORKDIR /zeppelin-0.6.2-bin-all
 ADD zeppelin-env.sh conf/zeppelin-env.sh
 
 CMD ["bin/zeppelin.sh", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mesosphere/mesos:0.26.0-0.2.145.ubuntu1404
+FROM mesosphere/mesos:1.0.11.0.1-2.0.93.ubuntu1404
 
 RUN apt-get update && \
     apt-get install -y software-properties-common
@@ -20,9 +20,9 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 # zeppelin
-RUN wget http://apache.arvixe.com/incubator/zeppelin/0.5.6-incubating/zeppelin-0.5.6-incubating-bin-all.tgz
-RUN tar xzvf zeppelin-0.5.6-incubating-bin-all.tgz
-WORKDIR /zeppelin-0.5.6-incubating-bin-all
+RUN wget http://www.apache.org/dist/zeppelin/zeppelin-0.6.1/zeppelin-0.6.1-bin-all.tgz
+RUN tar xzvf zeppelin-0.6.1-bin-all.tgz
+WORKDIR /zeppelin-0.6.1-bin-all
 ADD zeppelin-env.sh conf/zeppelin-env.sh
 
 CMD ["bin/zeppelin.sh", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,8 @@ FROM mesosphere/mesos:1.0.11.0.1-2.0.93.ubuntu1404
 
 RUN apt-get update && \
     apt-get install -y software-properties-common
-RUN add-apt-repository ppa:openjdk-r/ppa
 RUN apt-get update && \
-    apt-get install --yes \
-    openjdk-8-jdk\
+    apt-get install -y \
     wget \
     tar
 
@@ -15,14 +13,65 @@ ADD ./conf/hadoop/hdfs-site.xml /etc/hadoop/hdfs-site.xml
 ADD ./conf/hadoop/core-site.xml /etc/hadoop/core-site.xml
 ADD ./conf/hadoop/mesos-site.xml /etc/hadoop/mesos-site.xml
 
-# java
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+# Oracle JDK8
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y oracle-java8-installer && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
 
-# zeppelin
-RUN wget http://www.apache.org/dist/zeppelin/zeppelin-0.6.2/zeppelin-0.6.2-bin-all.tgz
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+RUN update-alternatives --set java /usr/lib/jvm/java-8-oracle/jre/bin/java
+
+# Zeppelin
+RUN wget http://apache.claz.org/zeppelin/zeppelin-0.6.2/zeppelin-0.6.2-bin-all.tgz
 RUN tar xzvf zeppelin-0.6.2-bin-all.tgz
 WORKDIR /zeppelin-0.6.2-bin-all
 ADD zeppelin-env.sh conf/zeppelin-env.sh
+
+# R : https://www.digitalocean.com/community/tutorials/how-to-set-up-r-on-ubuntu-14-04
+RUN sh -c 'echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list'
+RUN gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
+RUN gpg -a --export E084DAB9 | sudo apt-key add -
+
+RUN apt-get update && \
+    apt-get install -y \
+    r-base \
+    ed \
+    liblzma-dev \
+    libssl-dev \
+    curl \
+    libcurl4-openssl-dev
+
+RUN R CMD javareconf
+RUN R -e "install.packages('devtools', repos = 'http://cran.us.r-project.org')"
+RUN R -e "install.packages('knitr', repos = 'http://cran.us.r-project.org')"
+RUN R -e "install.packages('ggplot2', repos = 'http://cran.us.r-project.org')"
+RUN R -e "install.packages('RWeka', repos = 'http://cran.us.r-project.org')"
+RUN R -e "install.packages(c('devtools','mplot', 'googleVis'), repos = 'http://cran.us.r-project.org'); require(devtools); install_github('ramnathv/rCharts')"
+RUN R -e "install.packages(c('glmnet', 'pROC', 'data.table', 'caret', 'sqldf', 'wordcloud'), repos = 'http://cran.us.r-project.org')"
+RUN cd ./interpreter/spark/R/lib/SparkR && R -e "devtools::install('.')"
+
+# Python
+RUN apt-get update && \
+    apt-get install -y \
+    python \
+    python-dev \
+    python-pip \
+    python-virtualenv \
+    python-matplotlib \
+    python-pandas
+
+RUN pip install \
+    py4j \
+    numpy \
+    matplotlib \
+    scipy \
+    pandas
+
+# Slimming down Docker container
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["bin/zeppelin.sh", "start"]

--- a/docs/user-docs.md
+++ b/docs/user-docs.md
@@ -1,6 +1,6 @@
 Apache Zeppelin is an interactive analytics notebook compatible with
 several backends, including [DC/OS
-Spark](https://docs.mesosphere.com/spark-1-7/).
+Spark](https://docs.mesosphere.com/1.8/usage/service-guides/spark/).
 
 DC/OS Zeppelin bundles Apache Zeppelin with the DC/OS Spark
 distribution.  For complete Apache Zeppelin docs, please visit [their
@@ -12,17 +12,17 @@ website](https://zeppelin.incubator.apache.org/).
 $ dcos package install zeppelin
 ```
 
-## Install on DC/OS 1.7 and above
-On DC/OS >= 1.7, you can now access Zeppelin at
+## Install on DC/OS 1.8 and above
+On DC/OS >= 1.8, you can now access Zeppelin at
 `http://<dcos_url>/service/zeppelin/` after running the above command.
 
 **Note:** Zeppelin uses websockets, which communicate over raw TCP
-sockets, rather than HTTP.  On AWS DC/OS 1.7, the ELB to which
+sockets, rather than HTTP.  On AWS DC/OS 1.8, the ELB to which
 `<dcos_url>` resolves will proxy HTTP traffic, but not TCP.  For
 Zeppelin to work properly, you must downgrade the ELB port 80 proxy to
 TCP.
 
-On DC/OS <1.7, you can access Zeppelin from the public internet by using marathon-lb [as described here](1.7/usage/service-discovery/marathon-lb/usage/).
+On DC/OS <1.8, you can access Zeppelin from the public internet by using marathon-lb [as described here](https://docs.mesosphere.com/1.8/usage/service-discovery/marathon-lb/usage/).
 
 <!-- 
 Alternately, you can deploy Zeppelin on a public agent by setting the

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
     "packagingVersion": "2.0",
     "name": "zeppelin",
-    "version": "0.5.6",
+    "version": "0.6.1",
     "scm": "https://github.com/apache/incubator-zeppelin",
     "maintainer": "support@mesosphere.io",
     "description": "Zeppelin is a web-based notebook that enables interactive data analytics",

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
     "packagingVersion": "2.0",
     "name": "zeppelin",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "scm": "https://github.com/apache/incubator-zeppelin",
     "maintainer": "support@mesosphere.io",
     "description": "Zeppelin is a web-based notebook that enables interactive data analytics",

--- a/package/resource.json
+++ b/package/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "zeppelin": "mesosphere/zeppelin:0.6.1",
+        "zeppelin": "mesosphere/zeppelin:0.6.2",
         "spark": "mesosphere/spark:1.0.2-2.0.0"
       }
     },

--- a/package/resource.json
+++ b/package/resource.json
@@ -7,12 +7,12 @@
   "assets": {
     "container": {
       "docker": {
-        "zeppelin": "mesosphere/zeppelin:0.5.6-3",
-        "spark": "mesosphere/spark:1.6.0"
+        "zeppelin": "mesosphere/zeppelin:0.6.1",
+        "spark": "mesosphere/spark:1.0.2-2.0.0"
       }
     },
     "uris": {
-      "spark": "https://downloads.mesosphere.io/spark/assets/spark-1.6.0.tgz"
+      "spark": "https://downloads.mesosphere.io/spark/assets/spark-2.0.0.tgz"
     }
   }
 }


### PR DESCRIPTION
In current version Zeppelin package allows only to use Scala in notebooks, because it's missing all the R and Python dependencies.

This PR installs not only Zeppelin itself, but also all the missing R and Python dependencies, including SparkR, which allows to run all of the Zeppelin examples.

I had to switch from OpenJDK8 to Oracle JDK8, to make rJava package work.